### PR TITLE
make unix socket permissions configurable via attribute

### DIFF
--- a/attributes/uwsgi.rb
+++ b/attributes/uwsgi.rb
@@ -1,4 +1,5 @@
 default['graphite']['uwsgi']['socket'] = '/tmp/uwsgi.sock'
+default['graphite']['uwsgi']['socket_permissions'] = '755'
 default['graphite']['uwsgi']['workers'] = 8
 default['graphite']['uwsgi']['carbon'] = '127.0.0.1:2003'
 default['graphite']['uwsgi']['listen_http'] = false

--- a/templates/default/sv-graphite-web-run.erb
+++ b/templates/default/sv-graphite-web-run.erb
@@ -11,6 +11,7 @@ exec uwsgi --processes <%= node['graphite']['uwsgi']['workers'] %> \
 --pythonpath <%= node['graphite']['base_dir'] %>/webapp/graphite \
 --wsgi-file <%= node['graphite']['base_dir'] %>/conf/graphite.wsgi.example \
 --uid <%= node['graphite']['user'] %> --gid <%= node['graphite']['group'] %> \
+--chmod-socket=<%= node['graphite']['uwsgi']['socket_permissions'] %> \
 --no-orphans --master \
 --procname graphite-web \
 --die-on-term \


### PR DESCRIPTION
This change allows a wrapper cookbook to set the node['graphite']['uwsgi']['socket_permissions'] attribute to set the file permissions on the unix socket.  The attribute is defaulted to 755, which is the previous observed value on Ubuntu.  

This can be useful for providing the web proxy (e.g. Nginx) with access to the socket.  In my own configuration, nginx installed via chef was denied permission to use the socket to proxy requests to graphite-web. 