### PR TITLE
remove ruby 1.9.3 and add 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.0
 bundler_args: --without development
 script:
   - bundle exec rake travis:ci


### PR DESCRIPTION
Due to Chef 12 not supporting Ruby 1.9.3 I'm removing it from Travis.
See https://www.chef.io/blog/2014/11/25/ruby-1-9-3-eol-and-chef-12/