### PR TITLE
create config dir before writing carbon config

### DIFF
--- a/recipes/_carbon_config.rb
+++ b/recipes/_carbon_config.rb
@@ -17,6 +17,14 @@
 # limitations under the License.
 #
 
+directory "conf dir" do
+  path "#{node['graphite']['base_dir']}/conf"
+  owner node['graphite']['user']
+  group node['graphite']['user']
+  mode 0755
+  recursive true
+end
+
 file "carbon.conf" do
   path "#{node['graphite']['base_dir']}/conf/carbon.conf"
   owner node['graphite']['user']

--- a/spec/recipes/_carbon_config_spec.rb
+++ b/spec/recipes/_carbon_config_spec.rb
@@ -3,6 +3,29 @@ require 'spec_helper'
 describe 'graphite::_carbon_config' do
   let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
   let(:file_resource) { chef_run.find_resource(:file, "carbon.conf") }
+  let(:dir_resource) { chef_run.find_resource(:directory, "conf dir") }
+
+  context "for the directory resource" do
+    it "has the path specified" do
+      expect(dir_resource.path).to eq('/opt/graphite/conf')
+    end
+
+    it "has the correct owner" do
+      expect(dir_resource.owner).to eq('graphite')
+    end
+
+    it "has the correct group" do
+      expect(dir_resource.group).to eq('graphite')
+    end
+
+    it "has correct mode" do
+      expect(dir_resource.mode).to eq(0755)
+    end
+
+    it "has recursive set" do
+      expect(dir_resource.recursive).to be true
+    end
+  end
 
   context "for the file resource" do
 


### PR DESCRIPTION
This PR ensures that the configuration directory is created before writing `carbon.conf`. Without this, the `_carbon_config` recipe will fail if you change the default paths.

Weirdly, if you leave the default paths alone, it works fine. My best guess is the packages create that directory for you.

### Reproduction

Override the default paths:

```
default['graphite']['base_dir']    = '/app/graphite'
default['graphite']['doc_root']    = '/app/graphite/webapp'
default['graphite']['storage_dir'] = '/app/graphite/storage'
```

... and then run the single node example. You should get this:

```
==> default: ================================================================================
==> default: Error executing action `create` on resource 'file[carbon.conf]'
==> default: ================================================================================
==> default: 
==> default: 
==> default: Chef::Exceptions::EnclosingDirectoryDoesNotExist
==> default: ------------------------------------------------
==> default: Parent directory /app/graphite/conf does not exist.
```