### PR TITLE
Fixed source URL for carbon

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@ default['graphite']['package_names'] = {
   },
   'carbon' => {
     'package' => 'carbon',
-    'source' => 'https://github.com/graphite-project/graphite-web/zipball/master'
+    'source' => 'https://github.com/graphite-project/carbon/zipball/master'
   },
   'graphite_web' => {
     'package' => 'graphite-web',


### PR DESCRIPTION
There was a typo in the URL for carbon (e.g. it was trying to install graphite-web a second time).