### PR TITLE
Add nofile resource limit support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ default['graphite']['user'] = 'graphite'
 default['graphite']['group'] = 'graphite'
 default['graphite']['base_dir'] = '/opt/graphite'
 default['graphite']['doc_root'] = '/opt/graphite/webapp'
+default['graphite']['limits']['nofile'] = 1024
 default['graphite']['storage_dir'] = '/opt/graphite/storage'
 default['graphite']['install_type'] = 'package'
 default['graphite']['package_names'] = {

--- a/templates/default/sv-carbon-run.erb
+++ b/templates/default/sv-carbon-run.erb
@@ -7,6 +7,9 @@ user="<%= node['graphite']['user'] %>"
 storage_path="<%= node['graphite']['storage_dir'] %>"
 daemon="<%= node['graphite']['base_dir']%>/bin/carbon-${type}.py"
 
+ulimit -H -n <%= node['graphite']['limits']['nofile'] %>
+ulimit -n <%= node['graphite']['limits']['nofile'] %>
+
 exec 2>&1
 
 exec chpst \

--- a/templates/default/sv-graphite-web-run.erb
+++ b/templates/default/sv-graphite-web-run.erb
@@ -1,17 +1,22 @@
 #!/bin/sh
+
+ulimit -H -n <%= node['graphite']['limits']['nofile'] %>
+ulimit -n <%= node['graphite']['limits']['nofile'] %>
+
 exec 2>&1
-exec uwsgi --processes <%= node['graphite']['uwsgi']['workers'] %> \
+exec chpst -- \
+    uwsgi --processes <%= node['graphite']['uwsgi']['workers'] %> \
 <% if node['graphite']['uwsgi']['carbon'] -%>
---plugins carbon --carbon <%= node['graphite']['uwsgi']['carbon'] %> \
+    --plugins carbon --carbon <%= node['graphite']['uwsgi']['carbon'] %> \
 <% end -%>
 <% if node['graphite']['uwsgi']['listen_http'] -%>
---http :<%= node['graphite']['uwsgi']['port'] %> \
+    --http :<%= node['graphite']['uwsgi']['port'] %> \
 <% end -%>
---pythonpath <%= node['graphite']['base_dir'] %>/lib \
---pythonpath <%= node['graphite']['base_dir'] %>/webapp/graphite \
---wsgi-file <%= node['graphite']['base_dir'] %>/conf/graphite.wsgi.example \
---uid <%= node['graphite']['user'] %> --gid <%= node['graphite']['group'] %> \
---no-orphans --master \
---procname graphite-web \
---die-on-term \
---socket <%= node['graphite']['uwsgi']['socket'] %>
+    --pythonpath <%= node['graphite']['base_dir'] %>/lib \
+    --pythonpath <%= node['graphite']['base_dir'] %>/webapp/graphite \
+    --wsgi-file <%= node['graphite']['base_dir'] %>/conf/graphite.wsgi.example \
+    --uid <%= node['graphite']['user'] %> --gid <%= node['graphite']['group'] %> \
+    --no-orphans --master \
+    --procname graphite-web \
+    --die-on-term \
+    --socket <%= node['graphite']['uwsgi']['socket'] %>


### PR DESCRIPTION
The default resource limit configuration for Carbon runs out of socket descriptors in high-usage deployments. This simple patch adds a configuration option for the max number of open files. For consistency, it also runs uWSGI through `chpst` as the cookbook currently does for the Carbon daemons.