### PR TITLE
use chmod-socket option in uwsgi so it can be overridden by a wrapper

### DIFF
--- a/attributes/uwsgi.rb
+++ b/attributes/uwsgi.rb
@@ -18,6 +18,7 @@
 #
 
 default['graphite']['uwsgi']['socket'] = '/tmp/uwsgi.sock'
+default['graphite']['uwsgi']['socket_permissions'] = '755'
 default['graphite']['uwsgi']['workers'] = 8
 default['graphite']['uwsgi']['carbon'] = '127.0.0.1:2003'
 default['graphite']['uwsgi']['listen_http'] = false

--- a/templates/default/sv-graphite-web-run.erb
+++ b/templates/default/sv-graphite-web-run.erb
@@ -11,6 +11,7 @@ exec uwsgi --processes <%= node['graphite']['uwsgi']['workers'] %> \
 --pythonpath <%= node['graphite']['base_dir'] %>/webapp/graphite \
 --wsgi-file <%= node['graphite']['base_dir'] %>/conf/graphite.wsgi.example \
 --uid <%= node['graphite']['user'] %> --gid <%= node['graphite']['group'] %> \
+--chmod-socket=<%= node['graphite']['uwsgi']['socket_permissions'] %> \
 --no-orphans --master \
 --procname graphite-web \
 --die-on-term \


### PR DESCRIPTION
use chmod-socket option in uwsgi so it can be overridden by a wrapper cookbook to allow access from the proxying web server.

Cherry pick #198 to make sure we PR to develop first.