### PR TITLE
Updated python dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -15,7 +15,7 @@ supports 'scientific'
 supports 'oracle'
 supports 'fedora'
 
-depends  'python'
+depends  'poise-python', '~> 1.4.0'
 depends  'runit', '~> 1.2'
 depends  'build-essential'
 depends  'yum-epel'


### PR DESCRIPTION
The python cookbook is deprecated and the advised one to use is poise-python. The deprecated version is causing installation problems with knife and the build shall fail with the chef 13 release onwards.