### PR TITLE
Create conf dir with group node['graphite']['group']

### DIFF
--- a/recipes/_carbon_config.rb
+++ b/recipes/_carbon_config.rb
@@ -20,7 +20,7 @@
 directory "conf dir" do
   path "#{node['graphite']['base_dir']}/conf"
   owner node['graphite']['user']
-  group node['graphite']['user']
+  group node['graphite']['group']
   mode 0755
   recursive true
 end


### PR DESCRIPTION
This fixes issue for those who don't have the same group name as user name.