### PR TITLE
Add support for Runit v2

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ supports 'oracle'
 supports 'fedora'
 
 depends  'python'
-depends  'runit', '~> 1.2'
+depends  'runit', '~> 1.2', '= 2.0.0'
 depends  'build-essential'
 depends  'yum-epel'
 


### PR DESCRIPTION
Changes are non-breaking in functionality, and include better test coverage, specifically for RHEL5.