### PR TITLE
allow for newer versions of runit cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ supports 'oracle'
 supports 'fedora'
 
 depends  'python'
-depends  'runit', '> 1.2'
+depends  'runit', '>= 1.2'
 depends  'build-essential'
 depends  'yum-epel'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ supports 'oracle'
 supports 'fedora'
 
 depends  'python'
-depends  'runit', '~> 1.2'
+depends  'runit', '> 1.2'
 depends  'build-essential'
 depends  'yum-epel'
 


### PR DESCRIPTION
This change allows for version `2.x` and `3.x` of the [runit](https://supermarket.chef.io/cookbooks/runit) cookbook.
# Why

I maintain cookbooks that require runit `>= 2.0.0` (and am currently using `3.0.0`). Berkshelf can't resolve the dependency graph if I include the latest stable (or development) `graphite` cookbook.

```
$ cat Berksfile
source "https://supermarket.chef.io"
cookbook 'graphite', '~> 1.0.4'
cookbook 'runit', '~> 3.0.0'

$ berks install --except raxvm
Resolving cookbook dependencies...
    ...
Fetching cookbook index from https://api.berkshelf.com/...
Unable to satisfy the following requirements:

- `runit (~> 3.0.0)` required by `user-specified dependency`
- `runit (~> 1.0)` required by `graphite-1.0.4`
```
